### PR TITLE
Refactor mutatieknoppen op website

### DIFF
--- a/applicatie/main/routes.py
+++ b/applicatie/main/routes.py
@@ -69,6 +69,7 @@ def matrix(jsonbestand, jsonbestandsnaam):
         # N.B. de dimensies eindigend op ':' bevatten de code + de omschrijving van de code
         # in de rijen van de matrix willen we namelijk ook de omschrijving tonen
 
+        # TODO Hier geen dubbele punt erin zetten, ergens anders oplossen
         lasten = DraaiTabel(
             data=data_geaggregeerd['lasten'],
             rij_naam='taakveld' + ':',              # taakveld inclusief omschrijving

--- a/applicatie/templates/macros.html
+++ b/applicatie/templates/macros.html
@@ -68,3 +68,28 @@
 {% endif %}
 
 {% endmacro %}
+
+{% macro record_toevoegen(draaitabel) %}
+
+<form class="form-inline text-center" role="form">
+    <div class="form-group" style="padding-right: 50px;">
+        <!-- TODO rstrip(:) is tijdelijk nodig om dubbele dubbele punt weg te halen. -->
+        <label for="rij">{{ draaitabel.rij_naam.title().rstrip(':') }}:&nbsp; </label>
+        <input class="form-control" style="width:100px;" id="rij">
+    </div>
+    <div class="form-group" style="padding-right: 50px;">
+        <label for="kolom">{{ draaitabel.kolom_naam.title().rstrip(':') }}:&nbsp; </label>
+        <input class="form-control" style="width:100px;" id="kolom">
+    </div>
+    <div class="form-group" style="padding-right: 50px;">
+        <label for="bedrag">Bedrag:&nbsp; </label>
+        <input class="form-control" style="width:100px;" id="bedrag">
+    </div>
+    <div class="form-group"><label style="width:100px;"></label></div>
+    <button class="btn btn-primary" type="button"
+            title="Functionaliteit is nog niet beschikbaar!"
+            onclick="alert('Deze functionaliteit is nog niet gebouwd.');">
+        Mutatie verwerken</button>
+</form>
+
+{% endmacro %}

--- a/applicatie/templates/matrix.html
+++ b/applicatie/templates/matrix.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% from 'macros.html' import draaitabel, controle_resultaat %}
+{% from 'macros.html' import draaitabel, controle_resultaat, record_toevoegen %}
 
 {% block content %}
 <style>
@@ -97,25 +97,7 @@ table {
 
         <!-- Tab content -->
         <div id='LastenLR' class="tabcontent">
-            <form class="form-inline text-center" role="form">
-            <div class="form-group" style="padding-right: 50px;">
-                <label for="rij">Taakveld:&nbsp; </label>
-	            <input class="form-control" style="width:100px;" id="rij">
-            </div>
-            <div class="form-group" style="padding-right: 50px;">
-                <label for="kolom">Categorie:&nbsp; </label>
-	            <input class="form-control" style="width:100px;" id="kolom">
-            </div>
-            <div class="form-group" style="padding-right: 50px;">
-                <label for="bedrag">Bedrag:&nbsp; </label>
-	            <input class="form-control" style="width:100px;" id="bedrag">
-            </div>
-                <div class="form-group"><label style="width:100px;"></label></div>
-                <button class="btn btn-primary" type="button"
-                        title="Functionaliteit is nog niet beschikbaar!"
-                        onclick="alert('Muteren functionaliteit is nog niet beschikbaar.');">
-                        Mutatie verwerken</button>
-            </form>
+            {{ record_toevoegen(lasten) }}
 
             <div style="clear:both;height:2em;"></div>
 
@@ -123,25 +105,7 @@ table {
         </div>
 
         <div id='BatenLR' class="tabcontent">
-            <form class="form-inline text-center" role="form">
-            <div class="form-group" style="padding-right: 50px;">
-                <label for="rij">Taakveld:&nbsp; </label>
-	            <input class="form-control" style="width:100px;" id="rij">
-            </div>
-            <div class="form-group" style="padding-right: 50px;">
-                <label for="kolom">Categorie:&nbsp; </label>
-	            <input class="form-control" style="width:100px;" id="kolom">
-            </div>
-            <div class="form-group" style="padding-right: 50px;">
-                <label for="bedrag">Bedrag:&nbsp; </label>
-	            <input class="form-control" style="width:100px;" id="bedrag">
-            </div>
-                <div class="form-group"><label style="width:100px;"></label></div>
-                <button class="btn btn-primary" type="button"
-                        title="Functionaliteit is nog niet beschikbaar!"
-                        onclick="alert('Muteren functionaliteit is nog niet beschikbaar.');">
-                        Mutatie verwerken</button>
-            </form>
+            {{ record_toevoegen(lasten) }}
 
             <div style="clear:both;height:2em;"></div>
 
@@ -149,25 +113,7 @@ table {
         </div>
 
         <div id="LastenBM" class="tabcontent">
-            <form class="form-inline text-center" role="form">
-            <div class="form-group" style="padding-right: 50px;">
-                <label for="rij">Balanscode:&nbsp; </label>
-	            <input class="form-control" style="width:100px;" id="rij">
-            </div>
-            <div class="form-group" style="padding-right: 50px;">
-                <label for="kolom">Categorie:&nbsp; </label>
-	            <input class="form-control" style="width:100px;" id="kolom">
-            </div>
-            <div class="form-group" style="padding-right: 50px;">
-                <label for="bedrag">Bedrag:&nbsp; </label>
-	            <input class="form-control" style="width:100px;" id="bedrag">
-            </div>
-                <div class="form-group"><label style="width:100px;"></label></div>
-                <button class="btn btn-primary" type="button"
-                        title="Functionaliteit is nog niet beschikbaar!"
-                        onclick="alert('Muteren functionaliteit is nog niet beschikbaar.');">
-                        Mutatie verwerken</button>
-            </form>
+            {{ record_toevoegen(balans_lasten) }}
 
             <div style="clear:both;height:2em;"></div>
 
@@ -175,25 +121,7 @@ table {
         </div>
 
         <div id='BatenBM' class="tabcontent">
-            <form class="form-inline text-center" role="form">
-            <div class="form-group" style="padding-right: 50px;">
-                <label for="rij">Balanscode:&nbsp; </label>
-	            <input class="form-control" style="width:100px;" id="rij">
-            </div>
-            <div class="form-group" style="padding-right: 50px;">
-                <label for="kolom">Categorie:&nbsp; </label>
-	            <input class="form-control" style="width:100px;" id="kolom">
-            </div>
-            <div class="form-group" style="padding-right: 50px;">
-                <label for="bedrag">Bedrag:&nbsp; </label>
-	            <input class="form-control" style="width:100px;" id="bedrag">
-            </div>
-                <div class="form-group"><label style="width:100px;"></label></div>
-                <button class="btn btn-primary" type="button"
-                        title="Functionaliteit is nog niet beschikbaar!"
-                        onclick="alert('Muteren functionaliteit is nog niet beschikbaar.');">
-                        Mutatie verwerken</button>
-            </form>
+            {{ record_toevoegen(balans_baten) }}
 
             <div style="clear:both;height:2em;"></div>
 


### PR DESCRIPTION
Dit vereenvoudigt de code om de mutatieknoppen toe te voegen

Ik had een beetje last van de dubbele punt die aan rij_naam en kolom_naam is toegevoegd.
Ik zie trouwens ook 'taakveld:' in de tabel staan, maar dat moet waarschijnlijk niet.

Voor de gebruiker maakt dit niet zo uit, dus hij hoeft niet vandaag gemerged.