### PR TITLE
Minder ingewikkelde manier om omschrijvingen te tonen in tabel

### DIFF
--- a/applicatie/logic/codelijst.py
+++ b/applicatie/logic/codelijst.py
@@ -1,0 +1,23 @@
+def maak_codelijst(codelijst):
+    """Gegeven een codelijst maak een mapping van code naar een omschrijving.
+
+    Bij geneste codelijsten, wordt een dubbele punt tussen de parent- en childomschrijving geplaatst.
+    """
+
+    omschrijvingen = {}
+    for item in codelijst:
+        code = item['code']
+
+        # TODO Gebruik omschrijving en verwijder oude naam description uit definitiebestanden
+        omschrijving = item.get('omschrijving') or item.get('description') or ''
+        omschrijvingen[code] = omschrijving
+
+        if 'subcodes' in item:
+            subcodes = maak_codelijst(item['subcodes'])
+
+            # Voeg parent- en subcode-omschrijving samen
+            subcode_update = {subcode: f"{omschrijving}: {subcode_omschrijving}"
+                              for (subcode, subcode_omschrijving) in subcodes.items()}
+            omschrijvingen.update(subcode_update)
+
+    return omschrijvingen

--- a/applicatie/logic/draaitabel.py
+++ b/applicatie/logic/draaitabel.py
@@ -7,7 +7,7 @@ WAARDE_KOLOM = 'bedrag'
 
 
 class DraaiTabel:
-   def __init__(self, data, rij_naam, kolom_naam):
+   def __init__(self, data, rij_naam, kolom_naam, rij_omschrijvingen, kolom_omschrijvingen):
        indices, self.tabel = pivot_table(data, aggregeer_kolommen=[rij_naam, kolom_naam],
                                          waarde_kolom=WAARDE_KOLOM)
        self.rij_naam, self.kolom_naam = rij_naam, kolom_naam
@@ -17,24 +17,27 @@ class DraaiTabel:
        self.kolommen = sorted(self.kolommen)
        self.data = data
 
+       # Onthoud omschrijvingen
+       self.rij_omschrijvingen = rij_omschrijvingen
+       self.kolom_omschrijvingen = kolom_omschrijvingen
+
    def __getitem__(self, args):
        """Geef een specifieke waarde uit de draaitabel terug."""
        return self.tabel[args]
 
    def geef_detail_kolommen(self):
         unieke_labels = reduce(set.union, [rij.keys() for rij in self.data], set())
-        r = self.rij_naam
-        k = self.kolom_naam
-        rs = r[:-1] if r[-1:] == ':' else r
-        ks = k[:-1] if k[-1:] == ':' else k
-        rsub = 'sub_' + rs
-        ksub = 'sub_' + ks
-        relevante_labels = unieke_labels - {r, k, rs, ks, rsub, ksub, WAARDE_KOLOM}
+        rsub = 'sub_' + self.rij_naam
+        ksub = 'sub_' + self.kolom_naam
+        relevante_labels = unieke_labels - {self.rij_naam, self.kolom_naam, rsub, ksub, WAARDE_KOLOM}
 
         # Sort labels alphabetically but always put value last
+        # TODO Waarom dit onderscheid?
         if ksub in unieke_labels:
-            details = [rs] + [ks] + [rsub] + [ksub] + sorted(relevante_labels, key=str.lower) + [WAARDE_KOLOM]
+            details = ([self.rij_naam] + [self.kolom_naam] + [rsub] + [ksub]
+                       + sorted(relevante_labels, key=str.lower) + [WAARDE_KOLOM])
         else:
-            details = [rs] + [ks] + [rsub] + sorted(relevante_labels, key=str.lower) + [WAARDE_KOLOM]
+            details = ([self.rij_naam] + [self.kolom_naam] + [rsub]
+                       + sorted(relevante_labels, key=str.lower) + [WAARDE_KOLOM])
 
         return details

--- a/applicatie/main/routes.py
+++ b/applicatie/main/routes.py
@@ -54,21 +54,21 @@ def matrix(jsonbestand, jsonbestandsnaam):
             # Controle databestand met definitiebestand
             fouten = controle_met_defbestand(data_bestand, definitie_bestand)
 
-        if fouten:
-            return render_template("index.html", errormessages=fouten)
+        if not fouten:
+            # json bestand is opgehaald en geen fouten zijn gevonden
+            # vervolgens data aggregeren en tonen op het scherm
+            data = data_bestand['data']
 
-        # json bestand is opgehaald en geen fouten zijn gevonden
-        # vervolgens data aggregeren en tonen op het scherm
-        data = data_bestand['data']
+            # de data volledig aggregeren
+            data_geaggregeerd, fouten = aggregeren_volledig(data, definitie_bestand)
 
-        # de data volledig aggregeren
-        data_geaggregeerd, fouten = aggregeren_volledig(data, definitie_bestand)
         if fouten:
             return render_template("index.html", errormessages=fouten)
 
         # Zoek omschrijvingen bij de codes zodat we deze in de tabel kunnen tonen
         omschrijvingen = {}
 
+        # TODO Misschien goed idee om een klasse Codelijst te maken
         for naam, codelijst in definitie_bestand['codelijsten'].items():
             omschrijvingen[naam] = maak_codelijst(codelijst['codelijst'])
 

--- a/applicatie/main/routes.py
+++ b/applicatie/main/routes.py
@@ -1,5 +1,6 @@
 from flask import render_template, request
 
+from applicatie.logic.codelijst import maak_codelijst
 from applicatie.logic.controles import controle_met_defbestand
 from applicatie.logic.draaitabel import DraaiTabel
 from applicatie.logic.inlezen import ophalen_en_controleren_databestand, ophalen_bestand_van_web
@@ -47,7 +48,7 @@ def matrix(jsonbestand, jsonbestandsnaam):
             overheidslaag = meta['overheidslaag']
             boekjaar = meta['boekjaar']
             bestandsnaam = IV3_DEF_FILE.format(overheidslaag, boekjaar)
-            definitie_bestand, fouten = ophalen_bestand_van_web(IV3_REPO_PATH, bestandsnaam, 'definitiebetand')
+            definitie_bestand, fouten = ophalen_bestand_van_web(IV3_REPO_PATH, bestandsnaam, 'definitiebestand')
 
         if not fouten:
             # Controle databestand met definitiebestand
@@ -65,35 +66,47 @@ def matrix(jsonbestand, jsonbestandsnaam):
         if fouten:
             return render_template("index.html", errormessages=fouten)
 
-        # per rekening de data aggregeren over de opgegeven dimensies
-        # N.B. de dimensies eindigend op ':' bevatten de code + de omschrijving van de code
-        # in de rijen van de matrix willen we namelijk ook de omschrijving tonen
+        # Zoek omschrijvingen bij de codes zodat we deze in de tabel kunnen tonen
+        omschrijvingen = {}
+
+        for naam, codelijst in definitie_bestand['codelijsten'].items():
+            omschrijvingen[naam] = maak_codelijst(codelijst['codelijst'])
 
         # TODO Hier geen dubbele punt erin zetten, ergens anders oplossen
         lasten = DraaiTabel(
             data=data_geaggregeerd['lasten'],
-            rij_naam='taakveld' + ':',              # taakveld inclusief omschrijving
-            kolom_naam='categorie')
+            rij_naam='taakveld',
+            kolom_naam='categorie',
+            rij_omschrijvingen=omschrijvingen['taakveld'],
+            kolom_omschrijvingen=omschrijvingen['categorie_lasten'])
 
         balans_lasten = DraaiTabel(
             data=data_geaggregeerd['balans_lasten'],
-            rij_naam='balanscode' + ':',            # balanscode inclusief omschrijving
-            kolom_naam='categorie')
+            rij_naam='balanscode',
+            kolom_naam='categorie',
+            rij_omschrijvingen=omschrijvingen['balanscode'],
+            kolom_omschrijvingen=omschrijvingen['categorie_baten'])
 
         baten = DraaiTabel(
             data=data_geaggregeerd['baten'],
-            rij_naam='taakveld' + ':',              # taakveld inclusief omschrijving
-            kolom_naam='categorie')
+            rij_naam='taakveld',
+            kolom_naam='categorie',
+            rij_omschrijvingen=omschrijvingen['taakveld'],
+            kolom_omschrijvingen=omschrijvingen['categorie_baten'])
 
         balans_baten = DraaiTabel(
             data=data_geaggregeerd['balans_baten'],
-            rij_naam='balanscode' + ':',            # balanscode inclusief omschrijving
-            kolom_naam='categorie')
+            rij_naam='balanscode',
+            kolom_naam='categorie',
+            rij_omschrijvingen=omschrijvingen['balanscode'],
+            kolom_omschrijvingen=omschrijvingen['categorie_lasten'])
 
         balans_standen = DraaiTabel(
             data=data_geaggregeerd['balans_standen'],
-            rij_naam='balanscode' + ':',            # balanscode inclusief omschrijving
-            kolom_naam='standper')
+            rij_naam='balanscode',
+            kolom_naam='standper',
+            rij_omschrijvingen=omschrijvingen['balanscode'],
+            kolom_omschrijvingen=omschrijvingen['standper'])
 
         # Voer controles uit
         plausibiliteitscontroles = [PlausibiliteitsControle(controle['omschrijving'],

--- a/applicatie/templates/macros.html
+++ b/applicatie/templates/macros.html
@@ -13,7 +13,7 @@
         <thead>
         <tr>
             <th colspan="1" rowspan="1"></th>
-            <th class="pvtAxisLabel">{{ tabel.kolom_naam }}</th>
+            <th class="pvtAxisLabel">{{ tabel.kolom_naam.title() }}</th>
 
             {% for kolom in tabel.kolommen %}
             <th class="pvtTable pvtColLabel" colspan="1" rowspan="2">
@@ -22,7 +22,7 @@
             {% endfor %}
         </tr>
         <tr>
-            <th class="pvtAxisLabel">{{ tabel.rij_naam }}</th>
+            <th class="pvtAxisLabel">{{ tabel.rij_naam.title() }}</th>
         </tr>
         </thead>
         <tbody>
@@ -30,7 +30,7 @@
         {% for rij in tabel.rijen %}
         <tr>
             <th class="pvtRowLabel" rowspan="1" colspan="2">
-                {{ rij }}
+                {{ rij }} {{ tabel.rij_omschrijvingen[rij] }}
             </th>
             {% for kolom in tabel.kolommen %}
             <td class="td default"


### PR DESCRIPTION
Ik vond de manier waarop omschrijvingen in de tabel terechtkwamen een beetje ingewikkeld, dus ik heb geprobeerd dit op een simpelere manier op te lossen. Ik weet ook niet of het toevoegen van een dubbele punt andere stukken in het programma moeilijker zal maken.

Het lost een paar schoonheidsfoutjes op, bijvoorbeeld nu staat er 'taakveld:', maar dat wil je denk ik niet.

Je hoeft dan in je functie waarin je aggregeert niets meer met omschrijvingen te doen, waardoor dat gedeelte van het programma simpeler wordt. Het maakt denk ik ook de downloadfunctionaliteit simpeler.

Kijk of dit in allen gevalle goed gaat en zo ja, dan kun je mergen.