### PR TITLE
Aanpassen aan iv3 data schema v1 1

### DIFF
--- a/applicatie/logic/inlezen.py
+++ b/applicatie/logic/inlezen.py
@@ -5,8 +5,8 @@ import urllib.request
 from collections import OrderedDict
 from json import JSONDecodeError
 from urllib.error import URLError, HTTPError
-from applicatie.logic.controles import controle_met_schema, controle_met_defbestand
-from config.configurations import IV3_REPO_PATH, IV3_DEF_FILE, IV3_SCHEMA_FILE
+from applicatie.logic.controles import controle_met_schema
+from config.configurations import IV3_REPO_PATH, IV3_SCHEMA_FILE
 
 _logger = logging.getLogger(__file__)
 
@@ -28,7 +28,7 @@ def ophalen_en_controleren_databestand(jsonbestand):
 
     if not fouten:
         # json schema ophalen van web
-        versie = "1_0"
+        versie = "1_1"
         bestandsnaam = IV3_SCHEMA_FILE.format(versie)
         schema_bestand, fouten = ophalen_bestand_van_web(IV3_REPO_PATH, bestandsnaam, 'schemabestand')
 

--- a/applicatie/static/js/matrix.js
+++ b/applicatie/static/js/matrix.js
@@ -4,8 +4,6 @@ function download_data(filename, meta, contact) {
 
     // TODO Dit is een beginnetje, maar bevat nu nog alleen de data (alles op een hoop)
     var data = {};
-    var meta = JSON.parse('{"gemeente": "CBS-dorp", "id":"XYZ12345"}');
-    var contact = JSON.parse('{"naam": "Vincent", "e-mail":"vs.ohm@cbs.nl"}');
 
     var tabellen = $('table.pvtTable.draaitabel');
     for (var i = 0; i < tabellen.length; i++) {
@@ -27,7 +25,7 @@ function download_data(filename, meta, contact) {
 
     // Generate download link
     var text = JSON.stringify(json_bestand, null, 2);
-    download('data.json', text);
+    download(filename, text);
 }
 
 function download(filename, text) {

--- a/applicatie/templates/matrix.html
+++ b/applicatie/templates/matrix.html
@@ -72,6 +72,7 @@ table {
             <div>Type: {{ meta['overheidslaag']}} nummer {{ meta['overheidsnummer']}}</div>
             <div>Periode: {{ meta['boekjaar']}} {{ meta['periode']}} {{meta['status']}}</div>
             <div>Datum : {{ meta['datum']}}</div>
+            <div>Software: {{ meta.get('software', 'onbekend') }}</div>
 
             <div>
                 Definitiebestand: {{ sjabloon['omschrijving'] }}, {{ sjabloon['overheidslaag'] }}, {{ sjabloon['boekjaar'] }}

--- a/applicatie/templates/matrix.html
+++ b/applicatie/templates/matrix.html
@@ -52,19 +52,18 @@ table {
 </style>
 
 
-<body>
+<body bgcolor="#1a1aff">
 
-    <script type="text/javascript" src="{{ url_for('static', filename='js/detail.js') }}" />
-    <script type="text/javascript" src="{{ url_for('static', filename='js/muteren.js') }}" />
+    <script type="text/javascript" src="{{ url_for('static', filename='js/detail.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='js/muteren.js') }}"></script>
 
-    <script>
-        data = {{ data | tojson }};
-        meta = {{ meta | tojson }};
-        contact = {{ contact | tojson }};
-        filename = {{ bestandsnaam | tojson }};
+    <script type="text/javascript">
+        var data = {{ data | tojson }};
+        var meta = {{ meta | tojson }};
+        var contact = {{ contact | tojson }};
+        var filename = {{ bestandsnaam | tojson }};
     </script>
 
-    <body bgcolor="#1a1aff">
     <font color="#FFFFFF">
         <div style="position: relative;left: 5px;font-size: 17px;padding: 10px;">
             <div>Bestand: {{ bestandsnaam }}</div>
@@ -77,16 +76,11 @@ table {
             <div>
                 Definitiebestand: {{ sjabloon['omschrijving'] }}, {{ sjabloon['overheidslaag'] }}, {{ sjabloon['boekjaar'] }}
 
-                <!-- Opmerking Vincent, 13-6-2019: -->
-                <!-- onderstaande werkte niet, gaf foutmelding: -->
-                <!-- ReferenceError: ... is not defined -->
-                <!-- onclick="download_data(filename, meta, contact);" -->
-                <!-- ik weet op dit moment niet hoe we dit kunnen fixen -->
                 <button
                         class="btn btn-primary"
                         type="button"
-                        title="Functionaliteit is nog niet beschikbaar!"
-                        onclick="download_data('', '', '');"
+                        title="Klik hier om json bestand te downloaden"
+                        onclick="download_data(filename, meta, contact);"
                         style="float: right" >
                     Data downloaden
                 </button>
@@ -186,6 +180,7 @@ table {
         </div>
 
     </font>
+
     <script>
 
     function openTab(evt, tabnaam) {


### PR DESCRIPTION
Wat kleine aanpassingen.
json_data_schema heeft twee optionele velden in 'meta' erbij gekregen: 'software' en 'publicatie'.

downloaden werkt weer: er moesten twee </script> end-tags worden toegevoegd in matrix.html.
